### PR TITLE
Stabilize HTMX-driven site initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,31 +42,17 @@
 
 <!-- JS -->
 
-<script >
-const partials = document.querySelectorAll('[hx-trigger="load"], [data-hx-trigger="load"]');
-const totalPartials = partials.length;
-let processedCount = 0;
+<script>
+const tryInitSite = () => {
+    window.initSite?.();
+};
 
-// Створюємо Set, щоб не рахувати один і той самий елемент двічі
-const processedElements = new Set();
-
-document.body.addEventListener("htmx:afterSettle", (event) => {
-    const target = event.target;
-
-    // Перевіряємо, чи цей елемент — один із наших паршалів і чи ми його ще не рахували
-    if (target.hasAttribute('hx-get') && !processedElements.has(target)) {
-        processedElements.add(target);
-        processedCount++;
-        
-        console.log(`(index): Завантажено ${processedCount} з ${totalPartials}`);
-
-        if (processedCount >= totalPartials) {
-            init(); // Ваша функція з import("./js/global.footer.js")
-        }
-    }
-});
+document.addEventListener("DOMContentLoaded", tryInitSite);
+document.body.addEventListener("htmx:afterSwap", tryInitSite);
+document.body.addEventListener("htmx:afterSettle", tryInitSite);
 </script>
     
+<script type="module" src="js/index.js"></script>
 
 </body>
 </html>

--- a/js/global.footer.js
+++ b/js/global.footer.js
@@ -2,43 +2,41 @@
  * Логіка для футера та загальних елементів інтерфейсу
  */
 
+let footerInitialized = false;
+
 export function initFooter() {
-    console.log("Footer script initialized");
+    if (footerInitialized) {
+        return true;
+    }
 
     const scrollBtn = document.getElementById("scrollTopBtn");
     const yearSpan = document.getElementById("year");
 
-    // 1. Оновлення поточного року
-    if (yearSpan) {
-        yearSpan.textContent = new Date().getFullYear();
+    if (!scrollBtn || !yearSpan) {
+        return false;
     }
 
-    // 2. Логіка кнопки "Вгору"
-    if (scrollBtn) {
-        // Функція для показу/приховування кнопки
-        const toggleScrollButton = () => {
-            if (window.scrollY > 400) {
-                scrollBtn.classList.add("show");
-            } else {
-                scrollBtn.classList.remove("show");
-            }
-        };
+    yearSpan.textContent = new Date().getFullYear();
 
-        // Слухаємо скрол
-        window.addEventListener("scroll", toggleScrollButton);
+    const toggleScrollButton = () => {
+        if (window.scrollY > 400) {
+            scrollBtn.classList.add("show");
+        } else {
+            scrollBtn.classList.remove("show");
+        }
+    };
 
-        // Плавний скрол вгору при натисканні
-        scrollBtn.addEventListener("click", () => {
-            window.scrollTo({
-                top: 0,
-                behavior: "smooth"
-            });
+    window.addEventListener("scroll", toggleScrollButton);
+
+    scrollBtn.addEventListener("click", () => {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
         });
+    });
 
-        // Викликаємо один раз одразу, якщо користувач вже посередині сторінки при завантаженні
-        toggleScrollButton();
-    }
+    toggleScrollButton();
+
+    footerInitialized = true;
+    return true;
 }
-
-// Автоматичний запуск при імпорті
-initFooter();

--- a/js/global.header.js
+++ b/js/global.header.js
@@ -1,11 +1,26 @@
+let headerInitialized = false;
+
+export function initHeader() {
+    if (headerInitialized) {
+        return true;
+    }
 
     const header = document.querySelector(".header");
+    if (!header) {
+        return false;
+    }
 
-    window.addEventListener("scroll", () => {
+    const onScroll = () => {
         if (window.scrollY > 80) {
             header.classList.add("scrolled");
         } else {
             header.classList.remove("scrolled");
         }
-    });
+    };
 
+    window.addEventListener("scroll", onScroll);
+    onScroll();
+
+    headerInitialized = true;
+    return true;
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,28 @@
+let isSiteInitialized = false;
+let modulesPromise;
+
+async function loadModules() {
+    if (!modulesPromise) {
+        modulesPromise = Promise.all([
+            import("./global.header.js"),
+            import("./global.footer.js")
+        ]);
+    }
+
+    return modulesPromise;
+}
+
+export async function initSite() {
+    if (isSiteInitialized) {
+        return;
+    }
+
+    const [{ initHeader }, { initFooter }] = await loadModules();
+
+    const isHeaderReady = initHeader();
+    const isFooterReady = initFooter();
+
+    isSiteInitialized = isHeaderReady && isFooterReady;
+}
+
+window.initSite = initSite;


### PR DESCRIPTION
### Motivation
- HTMX partials load asynchronously and earlier initialization relied on counting partials which could miss cases where DOM nodes weren't yet present, causing initialization to fail or throw.
- Header and footer scripts ran eagerly and assumed DOM elements exist, leading to errors when those elements were injected by HTMX.

### Description
- Replaced the partial-count-based init trigger in `index.html` with a small retry trigger that calls `window.initSite?.()` on `DOMContentLoaded`, `htmx:afterSwap`, and `htmx:afterSettle` to reliably attempt initialization when HTMX swaps occur.
- Added `js/index.js` that caches dynamic imports and exports `initSite()` which waits for `global.header.js` and `global.footer.js` modules and calls their idempotent initializers exactly once.
- Refactored `js/global.header.js` to export `initHeader()` which checks for the `.header` element, attaches the scroll listener only if present, applies initial scroll state, and is idempotent.
- Refactored `js/global.footer.js` to export `initFooter()` which verifies required footer elements (`#scrollTopBtn`, `#year`) exist before wiring behavior, removes eager auto-run on import, and is idempotent.

### Testing
- Ran `node --check js/index.js` and it succeeded.
- Ran `node --check js/global.header.js` and it succeeded.
- Ran `node --check js/global.footer.js` and it succeeded.
- Confirmed presence of initialization hooks with `rg -n "init\(|initSite|afterSwap|afterSettle|DOMContentLoaded" index.html js/*.js` which reported expected occurrences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba4055f748326a226796895aa23d9)