### PR TITLE
Add background image to header

### DIFF
--- a/css/global.header.css
+++ b/css/global.header.css
@@ -50,7 +50,7 @@ html {
     top: 0;
     left: 0;
     padding: 20px 0;
-    background: transparent;
+    background: linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.45)), url("../hero-bg.png") center/cover no-repeat;
     transition: all 0.4s ease;
     z-index: 1000;
 }
@@ -101,7 +101,7 @@ html {
 
 /* ЕФЕКТ ПРИ СКРОЛІ */
 .header.scrolled {
-    background: #1f2a1f;
+    background: linear-gradient(rgba(22, 32, 22, 0.92), rgba(22, 32, 22, 0.92)), url("../hero-bg.png") center/cover no-repeat;
     padding: 10px 0;
     box-shadow: 0 5px 15px rgba(0,0,0,0.3);
 }


### PR DESCRIPTION
### Motivation
- Improve header appearance and readability by using the site hero image as a background with a dark overlay so navigation remains legible.

### Description
- Update `css/global.header.css` to set `.header` background to `../hero-bg.png` with a semi-transparent gradient overlay and update `.header.scrolled` to retain the image with a stronger overlay for better contrast while scrolling.

### Testing
- Started a local server with `python3 -m http.server --directory /workspace/tamdegoru.github.io 4173` and captured a screenshot via Playwright which confirmed the header renders with the new background image and overlays.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699baa864ad483269a66bc556cf18295)