### PR TITLE
Add per-card hide-image button to gallery

### DIFF
--- a/css/galery.galery.css
+++ b/css/galery.galery.css
@@ -44,6 +44,12 @@
     gap: 20px;
 }
 
+.galery-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .galery-grid img {
     width: 100%;
     height: 250px;
@@ -54,6 +60,25 @@
 
 .galery-grid img:hover {
     transform: scale(1.05);
+}
+
+.hide-image-btn {
+    border: none;
+    border-radius: 8px;
+    padding: 10px 14px;
+    cursor: pointer;
+    background: #111;
+    color: #fff;
+    font-size: 14px;
+    transition: background 0.2s ease-in-out;
+}
+
+.hide-image-btn:hover {
+    background: #333;
+}
+
+.galery-card.is-hidden {
+    display: none;
 }
 
 .galery-footer {

--- a/js/index.js
+++ b/js/index.js
@@ -26,3 +26,12 @@ export async function initSite() {
 }
 
 window.initSite = initSite;
+
+window.hideGalleryImage = (button) => {
+    const card = button.closest(".galery-card");
+    if (!card) {
+        return;
+    }
+
+    card.classList.add("is-hidden");
+};

--- a/partials/galery.galery.html
+++ b/partials/galery.galery.html
@@ -18,10 +18,28 @@
 
 <!-- 6 ФОТО -->
 <section class="galery-grid">
-    <img src="images/gallery/gallery1.webp">
-    <img src="images/gallery/gallery2.jpg" alt="">
-    <img src="images/gallery/gallery3.jpg">
-    <img src="images/gallery/gallery4.webp">
-    <img src="images/gallery/gallery5.webp">
-    <img src="images/gallery/gallery6.jpg" alt="">
+    <div class="galery-card">
+        <img src="images/gallery/gallery1.webp" alt="Галерея 1">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery2.jpg" alt="Галерея 2">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery3.jpg" alt="Галерея 3">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery4.webp" alt="Галерея 4">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery5.webp" alt="Галерея 5">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery6.jpg" alt="Галерея 6">
+        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
 </section>


### PR DESCRIPTION
### Motivation
- Provide a simple per-image control to hide gallery items as requested by adding a "hide image" button for each gallery photo.

### Description
- Wrap each gallery image in a `.galery-card` container and add a `Приховати зображення` button inside each card in `partials/galery.galery.html`.
- Expose a global handler `window.hideGalleryImage(button)` in `js/index.js` that finds the nearest `.galery-card` and adds the `.is-hidden` class to hide it.
- Add layout and control styles in `css/galery.galery.css` including `.galery-card`, `.hide-image-btn`, and `.galery-card.is-hidden { display: none; }`.

### Testing
- Served the site locally with `python3 -m http.server 4173` and confirmed the page loads successfully.
- Ran a Playwright script that opened `http://127.0.0.1:4173/index.html`, clicked the first hide button, and captured a screenshot showing the card was hidden (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699baaf597948327a9c32bafa0f326cb)