### PR TITLE
Gallery: add mobile 'Show all' button and display 5 on mobile / 12 on desktop

### DIFF
--- a/css/galery.galery.css
+++ b/css/galery.galery.css
@@ -62,10 +62,16 @@
     transform: scale(1.05);
 }
 
-.hide-image-btn {
+.galery-actions {
+    display: flex;
+    justify-content: center;
+    padding: 0 40px 40px;
+}
+
+.show-all-gallery-btn {
     border: none;
     border-radius: 8px;
-    padding: 10px 14px;
+    padding: 12px 18px;
     cursor: pointer;
     background: #111;
     color: #fff;
@@ -73,12 +79,14 @@
     transition: background 0.2s ease-in-out;
 }
 
-.hide-image-btn:hover {
+.show-all-gallery-btn:hover {
     background: #333;
 }
 
-.galery-card.is-hidden {
-    display: none;
+@media (max-width: 767px) {
+    .galery-card.is-hidden-mobile {
+        display: none;
+    }
 }
 
 .galery-footer {

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,9 @@
 let isSiteInitialized = false;
 let modulesPromise;
 
+const MOBILE_MAX_WIDTH = 767;
+const MOBILE_VISIBLE_IMAGES = 5;
+
 async function loadModules() {
     if (!modulesPromise) {
         modulesPromise = Promise.all([
@@ -12,26 +15,50 @@ async function loadModules() {
     return modulesPromise;
 }
 
-export async function initSite() {
-    if (isSiteInitialized) {
+function initGalleryVisibility() {
+    const galleryGrid = document.querySelector("#galery-grid");
+    const showAllButton = document.querySelector("#show-all-gallery-btn");
+
+    if (!galleryGrid || !showAllButton) {
         return;
     }
 
+    const cards = Array.from(galleryGrid.querySelectorAll(".galery-card"));
+    const isMobile = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH}px)`).matches;
+
+    cards.forEach((card, index) => {
+        const shouldHideCard = isMobile && index >= MOBILE_VISIBLE_IMAGES;
+        card.classList.toggle("is-hidden-mobile", shouldHideCard);
+    });
+
+    showAllButton.hidden = !isMobile;
+
+    showAllButton.onclick = () => {
+        cards.forEach((card) => {
+            card.classList.remove("is-hidden-mobile");
+        });
+
+        showAllButton.hidden = true;
+    };
+}
+
+export async function initSite() {
     const [{ initHeader }, { initFooter }] = await loadModules();
 
     const isHeaderReady = initHeader();
     const isFooterReady = initFooter();
+
+    initGalleryVisibility();
 
     isSiteInitialized = isHeaderReady && isFooterReady;
 }
 
 window.initSite = initSite;
 
-window.hideGalleryImage = (button) => {
-    const card = button.closest(".galery-card");
-    if (!card) {
+window.addEventListener("resize", () => {
+    if (!isSiteInitialized) {
         return;
     }
 
-    card.classList.add("is-hidden");
-};
+    initGalleryVisibility();
+});

--- a/partials/galery.galery.html
+++ b/partials/galery.galery.html
@@ -16,30 +16,46 @@
     </div>
 </div>
 
-<!-- 6 ФОТО -->
-<section class="galery-grid">
+<!-- 12 ФОТО -->
+<section class="galery-grid" id="galery-grid">
     <div class="galery-card">
         <img src="images/gallery/gallery1.webp" alt="Галерея 1">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
     </div>
     <div class="galery-card">
         <img src="images/gallery/gallery2.jpg" alt="Галерея 2">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
     </div>
     <div class="galery-card">
         <img src="images/gallery/gallery3.jpg" alt="Галерея 3">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
     </div>
     <div class="galery-card">
         <img src="images/gallery/gallery4.webp" alt="Галерея 4">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
     </div>
     <div class="galery-card">
         <img src="images/gallery/gallery5.webp" alt="Галерея 5">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
     </div>
     <div class="galery-card">
         <img src="images/gallery/gallery6.jpg" alt="Галерея 6">
-        <button class="hide-image-btn" type="button" onclick="hideGalleryImage(this)">Приховати зображення</button>
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery1.webp" alt="Галерея 7">
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery2.jpg" alt="Галерея 8">
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery3.jpg" alt="Галерея 9">
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery4.webp" alt="Галерея 10">
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery5.webp" alt="Галерея 11">
+    </div>
+    <div class="galery-card">
+        <img src="images/gallery/gallery6.jpg" alt="Галерея 12">
     </div>
 </section>
+
+<div class="galery-actions">
+    <button id="show-all-gallery-btn" class="show-all-gallery-btn" type="button">Показати всі зображення</button>
+</div>


### PR DESCRIPTION
### Motivation
- Make the gallery behave responsively so mobile users see a compact initial set of images with a single control to reveal the rest, and desktop users see all images by default.
- Remove per-image "hide" controls which are redundant when a single global action is sufficient.

### Description
- Updated `partials/galery.galery.html` to render 12 `.galery-card` items and removed per-card `Приховати зображення` buttons, adding a single `#show-all-gallery-btn` under the grid.
- Added responsive logic in `js/index.js` with `MOBILE_MAX_WIDTH` and `MOBILE_VISIBLE_IMAGES`, implemented `initGalleryVisibility()` to hide images after the first 5 on mobile and reveal them when `#show-all-gallery-btn` is clicked, and re-run visibility on window `resize`.
- Updated `css/galery.galery.css` to add `.galery-actions`, `.show-all-gallery-btn` styles and an `@media (max-width: 767px)` rule for `.galery-card.is-hidden-mobile`.

### Testing
- Ran the grep validation `rg "hideGalleryImage|hide-image-btn|show-all-gallery-btn|is-hidden-mobile|MOBILE_VISIBLE_IMAGES" -n partials/galery.galery.html js/index.js css/galery.galery.css` which succeeded.
- Verified there are 12 gallery cards with `rg -n "<div class=\"galery-card\"" partials/galery.galery.html | wc -l` (result: `12`).
- Served the site with `python3 -m http.server 4173` and captured a mobile viewport screenshot using Playwright which confirmed the initial 5-image view and the presence of the "Показати всі зображення" button (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bada2b4348326bfefe59ca37df531)