### PR TITLE
Add accommodation page with reusable room-card partials

### DIFF
--- a/css/accomondation.rooms.css
+++ b/css/accomondation.rooms.css
@@ -1,0 +1,77 @@
+.accomondation {
+    max-width: 1100px;
+    margin: 40px auto;
+    padding: 0 16px;
+}
+
+.accomondation-title {
+    text-align: center;
+    margin-bottom: 24px;
+    font-size: 32px;
+    color: #24463b;
+}
+
+.accomondation-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px;
+}
+
+.room-card {
+    background: #ffffff;
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+}
+
+.room-card-image {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+}
+
+.room-card-body {
+    padding: 14px 16px 18px;
+}
+
+.room-card-title {
+    margin: 0 0 10px;
+    color: #1f3c32;
+}
+
+.room-card-description {
+    margin: 0 0 14px 18px;
+    padding: 0;
+    color: #2f2f2f;
+}
+
+.room-card-description li {
+    margin-bottom: 4px;
+}
+
+.room-card-button {
+    border: none;
+    border-radius: 10px;
+    background: #1f6b54;
+    color: #ffffff;
+    padding: 10px 14px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.room-card-button:hover {
+    background: #16513f;
+}
+
+.room-card-more {
+    margin-top: 12px;
+    color: #2f2f2f;
+}
+
+@media (max-width: 768px) {
+    .accomondation-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/css/index.accomondation.css
+++ b/css/index.accomondation.css
@@ -1,0 +1,3 @@
+@import url("global.header.css");
+@import url("global.footer.css");
+@import url("accomondation.rooms.css");

--- a/index.accomondation.html
+++ b/index.accomondation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="
+    default-src 'self'; 
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; 
+    style-src 'self' 'unsafe-inline'; 
+    img-src 'self' data:;
+    connect-src 'self' https://unpkg.com;
+">
+    <title>Оренда житла</title>
+    <link rel="icon" href="images/logohata.png" type="image/x-icon">
+
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <link rel="stylesheet" href="css/index.accomondation.css">
+</head>
+<body>
+
+<div 
+    hx-get="partials/global.header.html"
+    hx-trigger="load"
+    hx-swap="outerHTML">
+</div>
+
+<div 
+    hx-get="partials/accomondation.rooms.html"
+    hx-trigger="load"
+    hx-swap="outerHTML">
+</div>
+
+<div 
+    hx-get="partials/global.footer.html"
+    hx-trigger="load"
+    hx-swap="outerHTML">
+</div>
+
+<script>
+const tryInitSite = () => {
+    window.initSite?.();
+};
+
+document.addEventListener("DOMContentLoaded", tryInitSite);
+document.body.addEventListener("htmx:afterSwap", tryInitSite);
+document.body.addEventListener("htmx:afterSettle", tryInitSite);
+</script>
+
+<script type="module" src="js/index.accomondation.js"></script>
+</body>
+</html>

--- a/js/index.accomondation.js
+++ b/js/index.accomondation.js
@@ -1,0 +1,47 @@
+let isSiteInitialized = false;
+let modulesPromise;
+
+async function loadModules() {
+    if (!modulesPromise) {
+        modulesPromise = Promise.all([
+            import("./global.header.js"),
+            import("./global.footer.js")
+        ]);
+    }
+    return modulesPromise;
+}
+
+function initRoomCards() {
+    const roomCards = document.querySelectorAll("[data-room-card]");
+
+    roomCards.forEach((card) => {
+        const button = card.querySelector("[data-room-button]");
+        const moreText = card.querySelector("[data-room-more]");
+
+        if (!button || !moreText) return;
+
+        button.onclick = () => {
+            const isHidden = moreText.hidden;
+            moreText.hidden = !isHidden;
+            button.textContent = isHidden ? "Сховати" : "Дізнатися більше";
+        };
+    });
+}
+
+export async function initSite() {
+    const [{ initHeader }, { initFooter }] = await loadModules();
+
+    const isHeaderReady = initHeader();
+    const isFooterReady = initFooter();
+
+    initRoomCards();
+
+    isSiteInitialized = isHeaderReady && isFooterReady;
+}
+
+window.initSite = initSite;
+
+window.addEventListener("resize", () => {
+    if (!isSiteInitialized) return;
+    initRoomCards();
+});

--- a/partials/accomondation.rooms.html
+++ b/partials/accomondation.rooms.html
@@ -1,0 +1,69 @@
+<section class="accomondation" id="accomondation">
+    <h2 class="accomondation-title">Наші номери</h2>
+
+    <div class="accomondation-grid">
+        <article class="room-card" data-room-card>
+            <img src="images/gallery/kimnata1.jpg" alt="Сімейний номер" class="room-card-image">
+            <div class="room-card-body">
+                <h3 class="room-card-title">Сімейний номер</h3>
+                <ul class="room-card-description">
+                    <li>До 4 гостей</li>
+                    <li>Вид на гори</li>
+                    <li>Сніданок включено</li>
+                </ul>
+                <button type="button" class="room-card-button" data-room-button>Дізнатися більше</button>
+                <p class="room-card-more" data-room-more hidden>
+                    Просторий номер з окремою зоною відпочинку, ортопедичними ліжками та великим балконом.
+                </p>
+            </div>
+        </article>
+
+        <article class="room-card" data-room-card>
+            <img src="images/gallery/kimnata2.jpg" alt="Стандартний номер" class="room-card-image">
+            <div class="room-card-body">
+                <h3 class="room-card-title">Стандартний номер</h3>
+                <ul class="room-card-description">
+                    <li>До 2 гостей</li>
+                    <li>Телевізор та Wi‑Fi</li>
+                    <li>Сучасна ванна кімната</li>
+                </ul>
+                <button type="button" class="room-card-button" data-room-button>Дізнатися більше</button>
+                <p class="room-card-more" data-room-more hidden>
+                    Затишний номер для парного відпочинку з комфортним ліжком, робочим столом і шафою.
+                </p>
+            </div>
+        </article>
+
+        <article class="room-card" data-room-card>
+            <img src="images/gallery/kimnata3.jpg" alt="Покращений номер" class="room-card-image">
+            <div class="room-card-body">
+                <h3 class="room-card-title">Покращений номер</h3>
+                <ul class="room-card-description">
+                    <li>Панорамні вікна</li>
+                    <li>Кондиціонер</li>
+                    <li>Міні‑бар</li>
+                </ul>
+                <button type="button" class="room-card-button" data-room-button>Дізнатися більше</button>
+                <p class="room-card-more" data-room-more hidden>
+                    Ідеальний варіант для тривалого проживання: більше простору, додаткові меблі та тиха атмосфера.
+                </p>
+            </div>
+        </article>
+
+        <article class="room-card" data-room-card>
+            <img src="images/gallery/kimnata4.jpg" alt="Люкс" class="room-card-image">
+            <div class="room-card-body">
+                <h3 class="room-card-title">Люкс</h3>
+                <ul class="room-card-description">
+                    <li>Окрема спальня</li>
+                    <li>Преміум сервіс</li>
+                    <li>Зона для роботи</li>
+                </ul>
+                <button type="button" class="room-card-button" data-room-button>Дізнатися більше</button>
+                <p class="room-card-more" data-room-more hidden>
+                    Номер найвищого класу з покращеним інтер'єром, м'якими меблями й додатковими зручностями.
+                </p>
+            </div>
+        </article>
+    </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a dedicated “Оренда житла” page that lists rooms using reusable partials and matches the site header/footer pattern. 
- Display at least four room blocks arranged two-per-row on desktop with compact mobile fallback and a way to reveal extra details.

### Description
- Added `index.accomondation.html` which loads header/footer and the rooms partial via HTMX and includes page-specific CSS and JS. 
- Introduced `partials/accomondation.rooms.html` containing 4 room cards each with a title, image, bullet-point features, a `Дізнатися більше` button and hidden extended text. 
- Added styles in `css/accomondation.rooms.css` and `css/index.accomondation.css` implementing a responsive 2-column grid on desktop and 1-column on mobile, plus card/button styling. 
- Added `js/index.accomondation.js` to initialize global header/footer modules and to toggle the extended room description when the room button is clicked.

### Testing
- Started a local server with `python3 -m http.server 4173` and confirmed the page responded successfully. 
- Ran an automated browser check with Playwright to open `http://127.0.0.1:4173/index.accomondation.html` and capture a full-page screenshot, which succeeded and produced an artifact. 
- Observed a couple of missing asset 404s in the server log during the run, but the new page and room cards loaded and the toggle interaction initialized correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9fba7314832aa783bb70342dcea8)