### PR TITLE
Fix mobile burger menu behavior and hero header styling

### DIFF
--- a/css/global.header.css
+++ b/css/global.header.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
 /* 1. Скидання стилів та базові налаштування */
 * {
     box-sizing: border-box;
@@ -91,7 +90,7 @@ body {
 /* 5. HERO СЕКЦІЯ */
 .hero {
     height: 100vh;
-    background: url("images/gallery/gallery3.jpg") center/cover no-repeat;
+    background: url("../images/header.hero.bg.jpg") center/cover no-repeat;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -121,19 +120,14 @@ body {
 }
 
 .hero h1 {
-    font-family: 'Pacifico', cursive;
-    font-size: clamp(36px, 9vw, 70px); /* Pacifico трохи дрібніший, тому я трохи збільшив значення */
-    font-weight: 400;
+    font-family: 'Trebuchet MS', 'Segoe UI', Arial, sans-serif;
+    font-size: clamp(30px, 7vw, 62px);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: 0.01em;
     color: white;
     text-shadow: 2px 2px 10px rgba(0,0,0,0.5);
     margin-bottom: 20px;
-}
-.hero-image {
-    max-width: 100%;
-    height: auto;
-    border-radius: 12px;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.4);
-    margin-top: 10px;
 }
 
 /* 6. АДАПТИВНІСТЬ (MOBILE) */

--- a/index.html
+++ b/index.html
@@ -6,8 +6,9 @@
     <meta http-equiv="Content-Security-Policy" content="
     default-src 'self'; 
     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; 
-    style-src 'self' 'unsafe-inline'; 
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; 
     img-src 'self' data:;
+    font-src 'self' https://fonts.gstatic.com;
     connect-src 'self' https://unpkg.com;
 ">
     <title>Home</title>

--- a/js/global.header.js
+++ b/js/global.header.js
@@ -1,13 +1,35 @@
 let headerInitialized = false;
 
 export function initHeader() {
-    if (headerInitialized) {
-        return true;
-    }
-
     const header = document.querySelector(".header");
+    const burger = document.querySelector("#burger-btn");
+    const nav = document.querySelector("#nav-menu");
+
     if (!header) {
         return false;
+    }
+
+    if (burger && nav) {
+        if (!burger.dataset.bound) {
+            burger.addEventListener("click", () => {
+                nav.classList.toggle("active");
+                burger.textContent = nav.classList.contains("active") ? "✕" : "☰";
+            });
+
+            const navLinks = nav.querySelectorAll("a");
+            navLinks.forEach((link) => {
+                link.addEventListener("click", () => {
+                    nav.classList.remove("active");
+                    burger.textContent = "☰";
+                });
+            });
+
+            burger.dataset.bound = "true";
+        }
+    }
+
+    if (headerInitialized) {
+        return true;
     }
 
     const onScroll = () => {

--- a/js/index.js
+++ b/js/index.js
@@ -118,28 +118,3 @@ window.addEventListener("resize", () => {
     if (!isSiteInitialized) return;
     initGalleryVisibility();
 });
-
-/*header*/
-const burger = document.getElementById('burger-btn');
-    const nav = document.getElementById('nav-menu');
-
-    burger.addEventListener('click', () => {
-        // Перемикаємо клас active для меню
-        nav.classList.toggle('active');
-        
-        // Змінюємо іконку бургера на "X" при відкритті
-        if (nav.classList.contains('active')) {
-            burger.textContent = '✕';
-        } else {
-            burger.textContent = '☰';
-        }
-    });
-
-    // Закриваємо меню при кліку на будь-яке посилання
-    const navLinks = document.querySelectorAll('.nav a');
-    navLinks.forEach(link => {
-        link.addEventListener('click', () => {
-            nav.classList.remove('active');
-            burger.textContent = '☰';
-        });
-    });

--- a/partials/global.header.html
+++ b/partials/global.header.html
@@ -18,6 +18,5 @@
     <section id="home" class="hero">
         <div class="hero-content">
             <h1>Місце, де зупиняється час і починаються гори</h1>
-            <img src="images/gallery/gallery1.jpg" alt="Головне зображення" class="hero-image">
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Ensure the mobile burger menu initializes only after the HTMX-injected header is present and avoid duplicate bindings that prevented the menu from opening on some devices. 
- Use an existing local header image as the hero background and fix h1 typography for consistent rendering across devices. 
- Allow Google Fonts resources in the page CSP so font loading is not blocked.

### Description
- Moved burger/menu initialization into `js/global.header.js` inside `initHeader()` and added a `data-bound` guard to prevent duplicate event binding. 
- Removed the duplicate burger/menu handlers from `js/index.js` so header logic is centralized and only runs after the header is injected. 
- Switched hero background to `images/header.hero.bg.jpg` and removed the redundant inline `<img>` from `partials/global.header.html`. 
- Updated hero typography in `css/global.header.css` (font stack, weight, size, `line-height`, and `letter-spacing`) and adjusted the background path to `../images/header.hero.bg.jpg`. 
- Expanded the Content-Security-Policy in `index.html` to include `https://fonts.googleapis.com` and `https://fonts.gstatic.com` for styles and fonts.

### Testing
- Static syntax checks passed: `node --check js/index.js` and `node --check js/global.header.js` (both OK). 
- Ran a local static server and verified in a mobile viewport that the burger opens/closes the menu and hero background loads correctly. 
- Automated browser test captured a verification screenshot artifact at `browser:/tmp/codex_browser_invocations/3b4a2389c00bb9d6/artifacts/artifacts/mobile-menu-hero.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb4836120832790ce793ce7448d11)