### PR TITLE
Перенесення сторінки на React з компонентами і маршрутизацією

### DIFF
--- a/my-react-app/src/App.css
+++ b/my-react-app/src/App.css
@@ -1,184 +1,72 @@
-.counter {
-  font-size: 16px;
-  padding: 5px 10px;
-  border-radius: 5px;
-  color: var(--accent);
-  background: var(--accent-bg);
-  border: 2px solid transparent;
-  transition: border-color 0.3s;
-  margin-bottom: 24px;
-
-  &:hover {
-    border-color: var(--accent-border);
-  }
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
+:root {
+  font-family: Inter, system-ui, Arial, sans-serif;
+  color: #1f2937;
+  background: #f8fafc;
 }
 
-.hero {
-  position: relative;
-
-  .base,
-  .framework,
-  .vite {
-    inset-inline: 0;
-    margin: 0 auto;
-  }
-
-  .base {
-    width: 170px;
-    position: relative;
-    z-index: 0;
-  }
-
-  .framework,
-  .vite {
-    position: absolute;
-  }
-
-  .framework {
-    z-index: 1;
-    top: 34px;
-    height: 28px;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(44deg) rotateY(39deg)
-      scale(1.4);
-  }
-
-  .vite {
-    z-index: 0;
-    top: 107px;
-    height: 26px;
-    width: auto;
-    transform: perspective(2000px) rotateZ(300deg) rotateX(40deg) rotateY(39deg)
-      scale(0.8);
-  }
+body {
+  margin: 0;
 }
 
-#center {
+.header,
+.footer {
+  background: #0f766e;
+  color: white;
+  text-align: center;
+  padding: 1rem;
+}
+
+.nav {
   display: flex;
-  flex-direction: column;
-  gap: 25px;
-  place-content: center;
-  place-items: center;
-  flex-grow: 1;
-
-  @media (max-width: 1024px) {
-    padding: 32px 20px 24px;
-    gap: 18px;
-  }
+  gap: 1rem;
+  justify-content: center;
+  padding: 0.8rem;
+  background: #ccfbf1;
 }
 
-#next-steps {
-  display: flex;
-  border-top: 1px solid var(--border);
-  text-align: left;
-
-  & > div {
-    flex: 1 1 0;
-    padding: 32px;
-    @media (max-width: 1024px) {
-      padding: 24px 20px;
-    }
-  }
-
-  .icon {
-    margin-bottom: 16px;
-    width: 22px;
-    height: 22px;
-  }
-
-  @media (max-width: 1024px) {
-    flex-direction: column;
-    text-align: center;
-  }
+.nav-link {
+  text-decoration: none;
+  color: #134e4a;
+  font-weight: 600;
 }
 
-#docs {
-  border-right: 1px solid var(--border);
-
-  @media (max-width: 1024px) {
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
+.nav-link.active {
+  border-bottom: 2px solid #134e4a;
 }
 
-#next-steps ul {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  gap: 8px;
-  margin: 32px 0 0;
-
-  .logo {
-    height: 18px;
-  }
-
-  a {
-    color: var(--text-h);
-    font-size: 16px;
-    border-radius: 6px;
-    background: var(--social-bg);
-    display: flex;
-    padding: 6px 12px;
-    align-items: center;
-    gap: 8px;
-    text-decoration: none;
-    transition: box-shadow 0.3s;
-
-    &:hover {
-      box-shadow: var(--shadow);
-    }
-    .button-icon {
-      height: 18px;
-      width: 18px;
-    }
-  }
-
-  @media (max-width: 1024px) {
-    margin-top: 20px;
-    flex-wrap: wrap;
-    justify-content: center;
-
-    li {
-      flex: 1 1 calc(50% - 8px);
-    }
-
-    a {
-      width: 100%;
-      justify-content: center;
-      box-sizing: border-box;
-    }
-  }
+.layout {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.25rem;
 }
 
-#spacer {
-  height: 88px;
-  border-top: 1px solid var(--border);
-  @media (max-width: 1024px) {
-    height: 48px;
-  }
+.content {
+  background: white;
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 5px 14px rgba(15, 23, 42, 0.08);
 }
 
-.ticks {
-  position: relative;
+.filter-label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.filter-input {
   width: 100%;
+  max-width: 340px;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+}
 
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    top: -4.5px;
-    border: 5px solid transparent;
-  }
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
 
-  &::before {
-    left: 0;
-    border-left-color: var(--border);
-  }
-  &::after {
-    right: 0;
-    border-right-color: var(--border);
-  }
+th,
+td {
+  border: 1px solid #cbd5e1;
+  padding: 0.6rem;
+  text-align: left;
 }

--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,27 +1,37 @@
-import React from 'react';
-
-// Імпортуємо ваші компоненти (колишні partials)
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
-import HeroAboutUs from './components/HeroAboutUs';
-import Services from './components/Services';
-import SliderGallery from './components/SliderGallery';
-import AccommodationRooms from './components/AccommodationRooms';
-import Gallery from './components/Gallery';
+import Navigation from './components/Navigation';
 import Footer from './components/Footer';
+import HomePage from './pages/HomePage';
+import AboutPage from './pages/AboutPage';
+import './App.css';
 
-// Імпортуємо стилі
-import './css/index.css';
+const navigationItems = [
+  { label: 'Головна', path: '/' },
+  { label: 'Про проєкт', path: '/about' },
+];
+
+const tableData = [
+  { id: 1, service: 'Проживання у котеджі', price: '1800 грн/доба', season: 'Цілий рік' },
+  { id: 2, service: 'Сніданок', price: '250 грн', season: 'Цілий рік' },
+  { id: 3, service: 'Екскурсія в гори', price: '900 грн', season: 'Весна-Осінь' },
+  { id: 4, service: 'Чан та сауна', price: '1200 грн', season: 'Цілий рік' },
+];
 
 export default function App() {
   return (
-    <>
-      <Header />
-      <HeroAboutUs />
-      <Services />
-      <SliderGallery />
-      <AccommodationRooms />
-      <Gallery />
+    <BrowserRouter>
+      <Header title={`Садиба "Горизонт" — лабораторна на React`} />
+      <Navigation items={navigationItems} />
+
+      <main className="layout">
+        <Routes>
+          <Route path="/" element={<HomePage tableData={tableData} />} />
+          <Route path="/about" element={<AboutPage />} />
+        </Routes>
+      </main>
+
       <Footer />
-    </>
+    </BrowserRouter>
   );
 }

--- a/my-react-app/src/components/Content.jsx
+++ b/my-react-app/src/components/Content.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+export default function Content({ tableData }) {
+  const [query, setQuery] = useState('');
+
+  const filteredRows = tableData.filter((row) =>
+    row.service.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  return (
+    <section className="content">
+      <h2>Наші послуги</h2>
+      <label className="filter-label" htmlFor="service-filter">
+        Фільтр за назвою послуги:
+      </label>
+      <input
+        id="service-filter"
+        className="filter-input"
+        type="text"
+        placeholder="Введіть назву..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
+      <table>
+        <thead>
+          <tr>
+            <th>Послуга</th>
+            <th>Вартість</th>
+            <th>Сезон</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filteredRows.map((row) => (
+            <tr key={row.id}>
+              <td>{row.service}</td>
+              <td>{row.price}</td>
+              <td>{row.season}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/my-react-app/src/components/Footer.jsx
+++ b/my-react-app/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="footer">
+      <p>© 2026 Садиба "Горизонт". Виконано для лабораторної роботи №3.</p>
+    </footer>
+  );
+}

--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -1,0 +1,7 @@
+export default function Header({ title }) {
+  return (
+    <header className="header">
+      <h1>{title}</h1>
+    </header>
+  );
+}

--- a/my-react-app/src/components/Navigation.jsx
+++ b/my-react-app/src/components/Navigation.jsx
@@ -1,0 +1,17 @@
+import { NavLink } from 'react-router-dom';
+
+export default function Navigation({ items }) {
+  return (
+    <nav className="nav">
+      {items.map((item) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/my-react-app/src/pages/AboutPage.jsx
+++ b/my-react-app/src/pages/AboutPage.jsx
@@ -1,0 +1,11 @@
+export default function AboutPage() {
+  return (
+    <section className="content">
+      <h2>Про проєкт</h2>
+      <p>
+        Ця сторінка демонструє перенесення статичного HTML-макета на React з
+        компонентним підходом, передачею props, використанням state та маршрутизацією.
+      </p>
+    </section>
+  );
+}

--- a/my-react-app/src/pages/HomePage.jsx
+++ b/my-react-app/src/pages/HomePage.jsx
@@ -1,0 +1,5 @@
+import Content from '../components/Content';
+
+export default function HomePage({ tableData }) {
+  return <Content tableData={tableData} />;
+}


### PR DESCRIPTION
### Motivation
- Портати попередню статичну HTML-сторінку в компонентний React-проєкт для кращої структури, повторного використання та інтерактивності.
- Забезпечити передачу даних через `props`, управління станом для інтерактивних елементів та клієнтську маршрутизацію для мінімум двох сторінок.

### Description
- Додано компоненти `Header`, `Navigation`, `Content` та `Footer` у `my-react-app/src/components` та сторінки `HomePage` і `AboutPage` у `my-react-app/src/pages` для розбиття макета по відповідальностях.
- Оновлено `my-react-app/src/App.jsx` для використання `BrowserRouter`, визначено маршрути `/` та `/about`, а також передається масив `navigationItems` і `tableData` через `props` у дочірні компоненти.
- У компоненті `Content` реалізовано фільтрацію таблиці послуг через React `useState` і поле вводу (`query`) для інтерактивності.
- Додано або оновлено стилі в `my-react-app/src/App.css` для базової стилізації заголовка, навігації, макета та таблиці.

### Testing
- Виконано спробу встановлення залежності `react-router-dom` через `cd my-react-app && npm install react-router-dom`, яка не пройшла через помилку `403 Forbidden` від npm registry, тому залежності не були встановлені.
- Спроба побудувати проєкт `cd my-react-app && npm run build` не вдалася через відсутність локально встановленого `vite` (`vite: not found`) у цьому середовищі через незавершену інсталяцію залежностей.
- Ніяких інших автоматизованих тестів або збірок виконано не було, тому повна перевірка роботи програми в runtime не завершена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fd7c6ef883279822271df7e85298)